### PR TITLE
Add docker ps output showing running 411-base-container

### DIFF
--- a/docker-ps-output.txt
+++ b/docker-ps-output.txt
@@ -1,0 +1,2 @@
+CONTAINER ID   IMAGE            COMMAND               CREATED          STATUS          PORTS     NAMES
+97de75283cbe   411-base-image   "tail -f /dev/null"   13 minutes ago   Up 13 minutes   443/tcp   411-base-container


### PR DESCRIPTION
This pull request includes the output from running the docker ps command to verify that the 411-base-container is running.